### PR TITLE
Feat: Initial support for multiple sinks

### DIFF
--- a/bspump/pipeline.py
+++ b/bspump/pipeline.py
@@ -96,6 +96,7 @@ class Pipeline(abc.ABC, asab.Configurable):
         self.Processors = [
             []
         ]  # List of lists of processors, the depth is increased by a Generator object
+        self.Sinks = []
 
         # Publish-Subscribe for this pipeline
         self.PubSub = asab.PubSub(app)
@@ -495,6 +496,17 @@ class Pipeline(abc.ABC, asab.Configurable):
                         self.ProcessorsCounter[processor.Id].add("event.drop", 1)
                         self.MetricsEPSCounter.add("eps.drop", 1)
                         self.MetricsCounter.add("event.drop", 1)
+                return
+        
+        if self.Sinks:
+            for c, s in self.Sinks:
+                if c(event):
+                    e = s.process(context, event)
+                    if e is not None:
+                        event = e
+                        break
+            else:
+                event = None
                 return
 
         assert event is not None

--- a/bspump/pipeline.py
+++ b/bspump/pipeline.py
@@ -804,7 +804,11 @@ class Pipeline(abc.ABC, asab.Configurable):
         """
         self.set_source(source)
         for processor in processors:
-            self.append_processor(processor)
+            if isinstance(processor, list):
+                for p in processor:
+                    self.Sinks.append((p[0], p[1]))
+            else:
+                self.append_processor(processor)
 
     def iter_processors(self):
         """

--- a/bspump/pipeline.py
+++ b/bspump/pipeline.py
@@ -497,7 +497,7 @@ class Pipeline(abc.ABC, asab.Configurable):
                         self.MetricsEPSCounter.add("eps.drop", 1)
                         self.MetricsCounter.add("event.drop", 1)
                 return
-        
+
         if self.Sinks:
             for c, s in self.Sinks:
                 if c(event):
@@ -789,16 +789,16 @@ class Pipeline(abc.ABC, asab.Configurable):
         )
 
         if isinstance(processor, Analyzer):
-            self.ProfilerCounter[
-                "analyzer_" + processor.Id
-            ] = self.MetricsService.create_counter(
-                "bspump.pipeline.profiler",
-                tags={
-                    "analyzer": processor.Id,
-                    "pipeline": self.Id,
-                },
-                init_values={"duration": 0.0, "run": 0},
-                reset=self.ResetProfiler,
+            self.ProfilerCounter["analyzer_" + processor.Id] = (
+                self.MetricsService.create_counter(
+                    "bspump.pipeline.profiler",
+                    tags={
+                        "analyzer": processor.Id,
+                        "pipeline": self.Id,
+                    },
+                    init_values={"duration": 0.0, "run": 0},
+                    reset=self.ResetProfiler,
+                )
             )
 
     def build(self, source, *processors):


### PR DESCRIPTION
- Adds initial support for multiple sinks in one pipeline
- Multiple sinks can be specified in `pipeline.build` as such 
```python
self.build(
            ...
            [
                (lambda e: e['count'] % 2, bspump.common.PPrintSink(app, self)),
                (lambda e: True, bspump.common.PPrintSink(app, self)),
            ]
        )
```
- Allows the following scenario
<img width="1341" alt="image" src="https://github.com/bitswan-space/BitSwan/assets/54212263/82e1ef9d-cd77-4f32-92a6-e3660853744a">

- To reproduce in `bspump.jupyter`, same structure can be applied to `register_sink` decorator
```python
@bpj.register_sink
def custom_sinks(app, pipeline):
    return [
        (lambda e: e["count"] % 2, bspump.common.PPrintSink(app, pipeline)),
        (lambda e: True, bspump.common.PPrintSink(app, pipeline)),
    ]
```