### PR TITLE
Async support in autopipeline

### DIFF
--- a/bspump/main.py
+++ b/bspump/main.py
@@ -51,7 +51,7 @@ return __bs_step_locals['event']
                             defaults=[],
                         ),
                         body=parsed_code.body,
-                        decorator_list=[ast.Name(id="step", ctx=ast.Load())],
+                        decorator_list=[ast.Name(id="async_step", ctx=ast.Load())],
                     )
 
                     # Step 4: Wrap the function definition in a module

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -106,12 +106,12 @@ def main():
                     notebook, out_path=f"{tmpdirname}/autopipeline_tmp.py"
                 )
                 sys.path.insert(0, tmpdirname)
-                tmp_module = __import__("autopipeline_tmp")
+                tmp_module = __import__("autopipeline_tmp")  # noqa: F405
         else:
             print(f"Notebook {app.Notebook} not found")
 
         if bspump.jupyter.bitswan_auto_pipeline.get("sink") is not None:
-            register_sink(
+            register_sink(  # noqa: F405
                 bspump.jupyter.bitswan_auto_pipeline.get("sink")
             )  # noqa: F405
             end_pipeline()  # noqa: F405

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -34,18 +34,22 @@ if not "__bs_step_locals" in globals():
     __bs_step_locals = {{}}
 # load locals from __bs_step_locals
 __bs_step_locals['event'] = event
+__bs_step_locals['inject'] = inject
 exec(__bs_cell_code_contents[{cell_number}] + "__bs_step_locals = locals()\\ndel __bs_step_locals['__bs_step_locals']",globals(), __bs_step_locals)
-return __bs_step_locals['event']
+await __bs_step_locals['inject'](__bs_step_locals['event'])
 """
 
                     parsed_code = ast.parse(clean_code)
 
                     # Step 3: Create a new function definition
-                    new_function = ast.FunctionDef(
+                    new_function = ast.AsyncFunctionDef(
                         name=f"step_{cell_number}_internal",
                         args=ast.arguments(
                             posonlyargs=[],
-                            args=[ast.arg(arg="event", annotation=None)],
+                            args=[
+                                ast.arg(arg="inject", annotation=None),
+                                ast.arg(arg="event", annotation=None),
+                            ],
                             kwonlyargs=[],
                             kw_defaults=[],
                             defaults=[],

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -30,12 +30,19 @@ class NotebookParser:
     def parse_cell(cls, cell, fout):
         def indent_code(lines: list[str]) -> list[str]:
             multiline = False
+            double_quotes = False
             indent_lines = []
             lines_out = []
             for i, line in enumerate(lines):
                 if not multiline and line.strip(" ") != "":
                     indent_lines.append(i)
-                if '"""' in line:
+                if '"""' in line or "'''" in line:
+                    if not multiline:
+                        double_quotes = '"""' in line
+                    elif (double_quotes and "'''" in line) or (
+                        not double_quotes and '"""' in line
+                    ):
+                        continue
                     multiline = not multiline
                     continue
             for i in range(len(lines)):

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -1,15 +1,16 @@
 import json
 import os
 import ast
-import asyncio
-
-config = None
-__bitswan_dev = False
-# cls._cell_code_contents: dict[int, str] = {}
-__bs_step_locals = {}
+import sys
+import tempfile
 
 from bspump.jupyter import *  # noqa: F403
 import bspump.jupyter
+
+config = None
+__bitswan_dev = False
+__bs_step_locals = {}
+
 
 def contains_function_call(ast_tree, function_name):
     for node in ast.walk(ast_tree):
@@ -17,6 +18,7 @@ def contains_function_call(ast_tree, function_name):
             if isinstance(node.func, ast.Name) and node.func.id == function_name:
                 return True
     return False
+
 
 class NotebookParser:
     _in_autopipeline = False
@@ -39,7 +41,7 @@ class NotebookParser:
                     continue
             lines_out = []
             for i in range(len(lines)):
-                _indent = ("    " if i in indent_lines else "")
+                _indent = "    " if i in indent_lines else ""
                 lines_out.append(_indent + lines[i])
             # return "\n".join([f"    {line}" for line in lines]) + "\n\n"
             return "\n".join(lines_out) + "\n\n"
@@ -63,8 +65,12 @@ class NotebookParser:
                 if not cls._in_autopipeline:
                     fout.write(cell_str(clean_code))
                 else:
-                    cls._cell_processor_contents[cls._cell_number] = cell_str(clean_code, True)
-                if not cls._in_autopipeline and contains_function_call(ast.parse(clean_code), "auto_pipeline"):
+                    cls._cell_processor_contents[cls._cell_number] = cell_str(
+                        clean_code, True
+                    )
+                if not cls._in_autopipeline and contains_function_call(
+                    ast.parse(clean_code), "auto_pipeline"
+                ):
                     cls._in_autopipeline = True
 
     @classmethod
@@ -77,10 +83,7 @@ class NotebookParser:
                 cls._cell_number += 1
                 cls.parse_cell(cell, f)
             # for cell_number, pcell in cls._cell_processor_contents:
-            print(f"PROCESSOR CONTENTS {cls._cell_processor_contents}")
-            j = ''.join(list(cls._cell_processor_contents.values()))
-            print(f"JOIN {j}")
-
+            # j = ''.join(list(cls._cell_processor_contents.values()))
 
             step_func_code = f"""@async_step
 async def processor_internal(inject, event):
@@ -90,29 +93,31 @@ async def processor_internal(inject, event):
             f.write(step_func_code)
 
 
-
-            
-
-
 def main():
     app = App()  # noqa: F405
     if app.Test:
         bspump.jupyter.bitswan_test_mode.append(True)
 
-    if os.path.exists(app.Notebook):
-        with open(app.Notebook) as nb:
-            notebook = json.load(nb)
-            NotebookParser.parse_notebook(notebook)
-            from tmp import app
-    else:
-        print(f"Notebook {app.Notebook} not found")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        if os.path.exists(app.Notebook):
+            with open(app.Notebook) as nb:
+                notebook = json.load(nb)
+                NotebookParser.parse_notebook(
+                    notebook, out_path=f"{tmpdirname}/autopipeline_tmp.py"
+                )
+                sys.path.insert(0, tmpdirname)
+                tmp_module = __import__("autopipeline_tmp")
+        else:
+            print(f"Notebook {app.Notebook} not found")
 
-    if bspump.jupyter.bitswan_auto_pipeline.get("sink") is not None:
-        register_sink(bspump.jupyter.bitswan_auto_pipeline.get("sink"))  # noqa: F405
-        end_pipeline()  # noqa: F405
+        if bspump.jupyter.bitswan_auto_pipeline.get("sink") is not None:
+            register_sink(
+                bspump.jupyter.bitswan_auto_pipeline.get("sink")
+            )  # noqa: F405
+            end_pipeline()  # noqa: F405
 
-    app.init_componets()
-    app.run()
+        app.init_componets()
+        app.run()
 
 
 if __name__ == "__main__":

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -106,7 +106,7 @@ def main():
                     notebook, out_path=f"{tmpdirname}/autopipeline_tmp.py"
                 )
                 sys.path.insert(0, tmpdirname)
-                tmp_module = __import__("autopipeline_tmp")  # noqa: F405
+                tmp_module = __import__("autopipeline_tmp")  # noqa: F841
         else:
             print(f"Notebook {app.Notebook} not found")
 

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -34,7 +34,7 @@ class NotebookParser:
             lines = contents.split("\n")
             indent_lines = []
             for i, line in enumerate(lines):
-                if not multiline:
+                if not multiline and line.strip(" ") != "":
                     indent_lines.append(i)
                 if '"""' in line:
                     multiline = not multiline
@@ -55,7 +55,8 @@ class NotebookParser:
                     else cell["source"]
                 )
                 clean_code = ""
-                for line in code.split("\n"):
+                # for line in code.split("\n"):
+                for line in list(filter(None, code.split("\n"))):
                     if line.startswith("!"):
                         continue
                     clean_code += line.replace("\t", "    ") + "\n"
@@ -87,9 +88,8 @@ class NotebookParser:
 
             step_func_code = f"""@async_step
 async def processor_internal(inject, event):
-{''.join(list(cls._cell_processor_contents.values()))}
-    await inject(event)
-            """
+{''.join(list(cls._cell_processor_contents.values()))}    await inject(event)
+"""
             f.write(step_func_code)
 
 

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -77,7 +77,6 @@ class NotebookParser:
                     self._in_autopipeline = True
 
     def parse_notebook(self, ntb, out_path="tmp.py"):
-        # print(f"BLOODY TYPE {self}")
         self._cell_number = 0
         self._in_autopipeline = False
         self._cell_processor_contents = {}
@@ -96,8 +95,6 @@ def main():
     app = App()  # noqa: F405
     parser = NotebookParser()
 
-    print(f"BLOODY TYPE {type(parser)}")
-    print(parser)
     if app.Test:
         bspump.jupyter.bitswan_test_mode.append(True)
 

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -44,7 +44,7 @@ def indent_code(lines: list[str]) -> list[str]:
     return lines_out
 
 
-class NotebookParser:
+class NotebookCompiler:
     _in_autopipeline = False
     _cell_number: int = 0
     _cell_processor_contents: dict[int, str] = {}
@@ -93,7 +93,7 @@ async def processor_internal(inject, event):
 
 def main():
     app = App()  # noqa: F405
-    parser = NotebookParser()
+    compiler = NotebookCompiler()
 
     if app.Test:
         bspump.jupyter.bitswan_test_mode.append(True)
@@ -102,7 +102,7 @@ def main():
         if os.path.exists(app.Notebook):
             with open(app.Notebook) as nb:
                 notebook = json.load(nb)
-                parser.parse_notebook(
+                compiler.parse_notebook(
                     notebook, out_path=f"{tmpdirname}/autopipeline_tmp.py"
                 )
                 sys.path.insert(0, tmpdirname)

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -76,7 +76,7 @@ class NotebookCompiler:
                 ):
                     self._in_autopipeline = True
 
-    def parse_notebook(self, ntb, out_path="tmp.py"):
+    def compile_notebook(self, ntb, out_path="tmp.py"):
         self._cell_number = 0
         self._in_autopipeline = False
         self._cell_processor_contents = {}
@@ -102,7 +102,7 @@ def main():
         if os.path.exists(app.Notebook):
             with open(app.Notebook) as nb:
                 notebook = json.load(nb)
-                compiler.parse_notebook(
+                compiler.compile_notebook(
                     notebook, out_path=f"{tmpdirname}/autopipeline_tmp.py"
                 )
                 sys.path.insert(0, tmpdirname)

--- a/examples/Testing/AutoPipeline/main.ipynb
+++ b/examples/Testing/AutoPipeline/main.ipynb
@@ -10,14 +10,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "1fd34891-3aac-4f76-9697-f8495a239091",
    "metadata": {},
    "outputs": [],
    "source": [
     "from bspump.jupyter import *\n",
     "from bspump.test import TestSink, TestSource\n",
-    "import json\n"
+    "import json\n",
+    "import asyncio\n"
    ]
   },
   {
@@ -32,12 +33,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "eb6f7aa2-4821-41eb-88ce-304e2756735f",
    "metadata": {},
    "outputs": [],
    "source": [
     "event = {}\n",
+    "# test_events = [({\"foo\":\"aaa\"},{\"expect\" : [{\"foo\": \"aaa\", \"barvar\": \"hello\", \"bazvar\": \"aaa\"}]}), \n",
+    "#                ({\"foo\":\"aab\"},{\"expect\" : [{\"foo\": \"aab\", \"barvar\": \"hello\", \"bazvar\": \"aab\"}]})]\n",
     "test_events = [({\"foo\":\"aaa\"},{\"expect\" : [{\"foo\": \"aaa\", \"foovar\": 3, \"barvar\": \"hello\", \"bazvar\": \"aaa\"}]}), \n",
     "               ({\"foo\":\"aab\"},{\"expect\" : [{\"foo\": \"aab\", \"foovar\": 3, \"barvar\": \"hello\", \"bazvar\": \"aab\"}]})]\n"
    ]
@@ -57,12 +60,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "08f23673",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'foo'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m barvar\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhello\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mawait\u001b[39;00m asyncio\u001b[38;5;241m.\u001b[39msleep(\u001b[38;5;241m0.2\u001b[39m)\n\u001b[0;32m----> 3\u001b[0m bazvar\u001b[38;5;241m=\u001b[39m\u001b[43mevent\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfoo\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'foo'"
+     ]
+    }
+   ],
    "source": [
     "barvar=\"hello\"\n",
+    "await asyncio.sleep(0.2)\n",
     "bazvar=event[\"foo\"]"
    ]
   },
@@ -84,6 +100,7 @@
     }
    ],
    "source": [
+    "print(\"Next step\")\n",
     "event[\"foovar\"] = foovar\n",
     "event[\"barvar\"] = barvar\n",
     "event[\"bazvar\"] = bazvar\n",
@@ -93,7 +110,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "bitswan",
    "language": "python",
    "name": "python3"
   },
@@ -107,7 +124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/test/jupyter/__init__.py
+++ b/test/jupyter/__init__.py
@@ -1,0 +1,1 @@
+from .test_jupyter import *

--- a/test/jupyter/expected.py
+++ b/test/jupyter/expected.py
@@ -8,7 +8,7 @@ foovar=3
 
 
 event = {}
-test_events = [({"foo":"aaa"},{"expect" : [{"foo": "aaa", "foovar": 3, "barvar": "hello", "bazvar": "aaa"}]}),
+test_events = [({"foo":"aaa"},{"expect" : [{"foo": "aaa", "foovar": 3, "barvar": "hello", "bazvar": "aaa"}]}), 
                ({"foo":"aab"},{"expect" : [{"foo": "aab", "foovar": 3, "barvar": "hello", "bazvar": "aab"}]})]
 
 

--- a/test/jupyter/expected.py
+++ b/test/jupyter/expected.py
@@ -1,0 +1,40 @@
+from bspump.jupyter import *
+from bspump.test import TestSink, TestSource
+import json
+import asyncio
+
+
+foovar=3
+
+
+event = {}
+test_events = [({"foo":"aaa"},{"expect" : [{"foo": "aaa", "foovar": 3, "barvar": "hello", "bazvar": "aaa"}]}),
+               ({"foo":"aab"},{"expect" : [{"foo": "aab", "foovar": 3, "barvar": "hello", "bazvar": "aab"}]})]
+
+
+auto_pipeline(
+    source=lambda app, pipeline: TestSource(app, pipeline, "TestSource"),
+    sink=lambda app, pipeline: TestSink(app, pipeline, "TestSink")
+)
+
+
+@async_step
+async def processor_internal(inject, event):
+    barvar="hello"
+    await asyncio.sleep(0.2)
+    my_multiline_string = """a line
+non-indented line
+    once indented line
+        twice indented line
+"""
+    bazvar=event["foo"]
+
+
+    print("Next step")
+    event["foovar"] = foovar
+    event["barvar"] = barvar
+    event["bazvar"] = bazvar
+    event
+
+
+    await inject(event)

--- a/test/jupyter/parse_example.ipynb
+++ b/test/jupyter/parse_example.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "be7f3cfc",
+   "metadata": {},
+   "source": [
+    "Test that globals and variables defined in processor steps are allowed to propagate to subsequent steps in the pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1fd34891-3aac-4f76-9697-f8495a239091",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bspump.jupyter import *\n",
+    "from bspump.test import TestSink, TestSource\n",
+    "import json\n",
+    "import asyncio\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ccb8d48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "foovar=3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eb6f7aa2-4821-41eb-88ce-304e2756735f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "event = {}\n",
+    "test_events = [({\"foo\":\"aaa\"},{\"expect\" : [{\"foo\": \"aaa\", \"foovar\": 3, \"barvar\": \"hello\", \"bazvar\": \"aaa\"}]}), \n",
+    "               ({\"foo\":\"aab\"},{\"expect\" : [{\"foo\": \"aab\", \"foovar\": 3, \"barvar\": \"hello\", \"bazvar\": \"aab\"}]})]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e5432e7-f84a-4b27-826a-5171e6112ba8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto_pipeline(\n",
+    "    source=lambda app, pipeline: TestSource(app, pipeline, \"TestSource\"),\n",
+    "    sink=lambda app, pipeline: TestSink(app, pipeline, \"TestSink\")\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "08f23673",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'foo'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m barvar\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhello\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mawait\u001b[39;00m asyncio\u001b[38;5;241m.\u001b[39msleep(\u001b[38;5;241m0.2\u001b[39m)\n\u001b[0;32m----> 3\u001b[0m bazvar\u001b[38;5;241m=\u001b[39m\u001b[43mevent\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mfoo\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'foo'"
+     ]
+    }
+   ],
+   "source": [
+    "barvar=\"hello\"\n",
+    "await asyncio.sleep(0.2)\n",
+    "my_multiline_string = \"\"\"a line\n",
+    "non-indented line\n",
+    "    once indented line\n",
+    "        twice indented line\n",
+    "\"\"\"\n",
+    "bazvar=event[\"foo\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "944f3fb3-74d5-45cc-8c8f-307f0d411de7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'foo': 'BAP'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(\"Next step\")\n",
+    "event[\"foovar\"] = foovar\n",
+    "event[\"barvar\"] = barvar\n",
+    "event[\"bazvar\"] = bazvar\n",
+    "event"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "bitswan",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test/jupyter/test_jupyter.py
+++ b/test/jupyter/test_jupyter.py
@@ -5,9 +5,10 @@ import pytest
 
 
 def test_notebook_parse_valid():
+    parser = NotebookParser()
     with open("jupyter/parse_example.ipynb", "r") as ntbf:
         ntb = json.load(ntbf)
-    NotebookParser.parse_notebook(ntb, "jupyter/tmp.py")
+    parser.parse_notebook(ntb, "jupyter/tmp.py")
     with open("jupyter/tmp.py", "r") as outf:
         out = ast.parse(outf.read())
     with open("jupyter/expected.py", "r") as expectf:
@@ -16,9 +17,10 @@ def test_notebook_parse_valid():
 
 
 def test_notebook_formatting():
+    parser = NotebookParser()
     with open("jupyter/parse_example.ipynb", "r") as ntbf:
         ntb = json.load(ntbf)
-    NotebookParser.parse_notebook(ntb, "jupyter/tmp.py")
+    parser.parse_notebook(ntb, "jupyter/tmp.py")
     with open("jupyter/tmp.py", "r") as outf:
         out = outf.read()
     with open("jupyter/expected.py", "r") as expectf:

--- a/test/jupyter/test_jupyter.py
+++ b/test/jupyter/test_jupyter.py
@@ -8,7 +8,7 @@ def test_notebook_parse_valid():
     compiler = NotebookCompiler()
     with open("jupyter/parse_example.ipynb", "r") as ntbf:
         ntb = json.load(ntbf)
-    compiler.parse_notebook(ntb, "jupyter/tmp.py")
+    compiler.compile_notebook(ntb, "jupyter/tmp.py")
     with open("jupyter/tmp.py", "r") as outf:
         out = ast.parse(outf.read())
     with open("jupyter/expected.py", "r") as expectf:
@@ -20,7 +20,7 @@ def test_notebook_formatting():
     compiler = NotebookCompiler()
     with open("jupyter/parse_example.ipynb", "r") as ntbf:
         ntb = json.load(ntbf)
-    compiler.parse_notebook(ntb, "jupyter/tmp.py")
+    compiler.compile_notebook(ntb, "jupyter/tmp.py")
     with open("jupyter/tmp.py", "r") as outf:
         out = outf.read()
     with open("jupyter/expected.py", "r") as expectf:

--- a/test/jupyter/test_jupyter.py
+++ b/test/jupyter/test_jupyter.py
@@ -1,14 +1,14 @@
-from bspump.main import NotebookParser
+from bspump.main import NotebookCompiler
 import json
 import ast
 import pytest
 
 
 def test_notebook_parse_valid():
-    parser = NotebookParser()
+    compiler = NotebookCompiler()
     with open("jupyter/parse_example.ipynb", "r") as ntbf:
         ntb = json.load(ntbf)
-    parser.parse_notebook(ntb, "jupyter/tmp.py")
+    compiler.parse_notebook(ntb, "jupyter/tmp.py")
     with open("jupyter/tmp.py", "r") as outf:
         out = ast.parse(outf.read())
     with open("jupyter/expected.py", "r") as expectf:
@@ -17,10 +17,10 @@ def test_notebook_parse_valid():
 
 
 def test_notebook_formatting():
-    parser = NotebookParser()
+    compiler = NotebookCompiler()
     with open("jupyter/parse_example.ipynb", "r") as ntbf:
         ntb = json.load(ntbf)
-    parser.parse_notebook(ntb, "jupyter/tmp.py")
+    compiler.parse_notebook(ntb, "jupyter/tmp.py")
     with open("jupyter/tmp.py", "r") as outf:
         out = outf.read()
     with open("jupyter/expected.py", "r") as expectf:

--- a/test/jupyter/test_jupyter.py
+++ b/test/jupyter/test_jupyter.py
@@ -1,0 +1,23 @@
+from bspump.main import NotebookParser
+import json
+import ast
+import pytest
+
+
+def test_notebook_parse_valid():
+    with open("jupyter/parse_example.ipynb", "r") as ntbf:
+        ntb = json.load(ntbf)
+    NotebookParser.parse_notebook(ntb, "jupyter/tmp.py")
+    with open("jupyter/tmp.py", "r") as outf:
+        out = ast.parse(outf.read())
+    with open("jupyter/expected.py", "r") as expectf:
+        expect = ast.parse(expectf.read())
+    assert ast.dump(out) == ast.dump(expect)
+
+
+def test_notebook_formatting():
+    assert False
+# def test_notebook_formatting():
+#     assert True
+# def test_notebook_formatting():
+#     assert True

--- a/test/jupyter/test_jupyter.py
+++ b/test/jupyter/test_jupyter.py
@@ -16,8 +16,11 @@ def test_notebook_parse_valid():
 
 
 def test_notebook_formatting():
-    assert False
-# def test_notebook_formatting():
-#     assert True
-# def test_notebook_formatting():
-#     assert True
+    with open("jupyter/parse_example.ipynb", "r") as ntbf:
+        ntb = json.load(ntbf)
+    NotebookParser.parse_notebook(ntb, "jupyter/tmp.py")
+    with open("jupyter/tmp.py", "r") as outf:
+        out = outf.read()
+    with open("jupyter/expected.py", "r") as expectf:
+        expect = expectf.read()
+    assert out == expect


### PR DESCRIPTION
Rewriting the processor steps of an auto pipeline to be `@async_step` by default, as per #53 

## TODO: Resolve inception problem with `await` executed within nested `exec`

This is a minimal reproduction of this issue:
```python
import asyncio
import ast

code=f"""print("Processing data...")
exec("await asyncio.sleep(2)")
print("Data processed.")
return 42
"""

parsed_code = ast.parse(code)
new_function = ast.AsyncFunctionDef(
    name=f"step_0_internal",
    args=ast.arguments(
        posonlyargs=[],
        args=[],
        kwonlyargs=[],
        kw_defaults=[],
        defaults=[],
    ),
    body=parsed_code.body,
    decorator_list=[],
)

module = ast.Module(body=[new_function], type_ignores=[])
module = ast.fix_missing_locations(module)
compiled_code = compile(module, filename="<ast>", mode="exec")
exec(compiled_code)
print("Function loaded")

def run_async_function():
    async def execute():
        result = await step_0_internal()  # Call the dynamically defined function
        print(f"Result: {result}")

    asyncio.run(execute())

exec(compiled_code)
run_async_function()
```
The nested exec on the async line in `code` fails with the same error as an example auto pipeline.
```
  File "<ast>", line 2, in step_0_internal
  File "<string>", line 1
SyntaxError: 'await' outside function
```
There is no issue without the wrapping `exec`