### PR TITLE
feat: implement restructure_data method for FieldSet

### DIFF
--- a/bspump/http/web/components/field_set.py
+++ b/bspump/http/web/components/field_set.py
@@ -31,3 +31,8 @@ class FieldSet(BaseField):
         return template.render(
             display=self.display, fieldset_intro=self.fieldset_intro, fields=fields_html
         )
+
+    def restructure_data(self, dfrom, dto):
+        dto[self.name] = {}
+        for field in self.fields:
+            field.restructure_data(dfrom, dto[self.name])


### PR DESCRIPTION
This source: 
```
WebFormSource(app, pipeline, route="/", fields=[
        TextField("foo", display="Foo"),
        TextField("la", readonly=True, default="laa"),
        IntField("n"),
        ChoiceField("lol", choices=["a","b","c"]),
        CheckboxField("checkbox"),
        FieldSet(name="user_info", fieldset_intro="User", fields=[
            TextField("name", display="Name"),
            TextField("age", readonly=True, default="laa"),
        ]),
    ])
```
was sending this data: {'foo': 'monika', 'la': 'laa', 'n': '0', 'lol': 'a', 'checkbox': False} so the data from FieldSet was missing which also raised missing Fields error. 
This happened because FieldSet is child of BaseField and not Field and therefore needed to have implemented the restructure_data method.
Now the sent data looks like this: 
{'foo': 'monika', 'la': 'laa', 'n': 0, 'lol': 'a', 'checkbox': False, 'user_info': {'name': 'dsdssa', 'age': 'laa'}}