### PR TITLE
cleaned typename and de-duplicated json

### DIFF
--- a/bspump/http/web/components/base_field.py
+++ b/bspump/http/web/components/base_field.py
@@ -13,7 +13,7 @@ class BaseField:
     def html(self, defaults) -> str:
         pass
 
-    def get_params(self, defaults) -> dict:
+    def get_params(defaults) -> dict:
         pass
 
     def restructure_data(self, dfrom, dto):

--- a/bspump/http/web/components/field.py
+++ b/bspump/http/web/components/field.py
@@ -57,4 +57,6 @@ class Field(BaseField):
         )
 
     def get_params(self, default="") -> dict:
-        return {self.name: {"type": str(type(self)), "description": self.description}}
+        if not default:
+            default = self.default
+        return {"type": type(self).__name__, "description": self.description}

--- a/bspump/http/web/components/field.py
+++ b/bspump/http/web/components/field.py
@@ -56,7 +56,5 @@ class Field(BaseField):
             inner_html=self.inner_html(default, self.readonly),
         )
 
-    def get_params(self, default="") -> dict:
-        if not default:
-            default = self.default
+    def get_params(self) -> dict:
         return {"type": type(self).__name__, "description": self.description}

--- a/bspump/http/web/components/field_set.py
+++ b/bspump/http/web/components/field_set.py
@@ -37,7 +37,7 @@ class FieldSet(BaseField):
         for field in self.fields:
             field.restructure_data(dfrom, dto[self.name])
 
-    def get_params(self, default="") -> dict:
+    def get_params(self) -> dict:
         out = {}
         for field in self.fields:
             out[field.name] = field.get_params()

--- a/bspump/http/web/components/field_set.py
+++ b/bspump/http/web/components/field_set.py
@@ -36,3 +36,9 @@ class FieldSet(BaseField):
         dto[self.name] = {}
         for field in self.fields:
             field.restructure_data(dfrom, dto[self.name])
+
+    def get_params(self, default="") -> dict:
+        out = {}
+        for field in self.fields:
+            out[field.name] = field.get_params()
+        return out

--- a/examples/ProtectedWebForm/main.ipynb
+++ b/examples/ProtectedWebForm/main.ipynb
@@ -50,7 +50,7 @@
     "        route=\"/\",\n",
     "        form_intro=\"\"\"<p>This is a protected form.</p>\"\"\",\n",
     "        fields=[\n",
-    "            TextField(\"foo\", display=\"Foo\"),\n",
+    "            TextField(\"foo\", display=\"Foo\", description=\"specify the foo\"),\n",
     "            TextField(\"la\", readonly=True, default=\"laa\"),\n",
     "            IntField(\"n\"),\n",
     "            TextField(\"bar\", hidden=True),\n",


### PR DESCRIPTION
When handling GET with json type, the WebForm duplicates the field name and has an unclean type name
```
{
  "foo": {
    "foo": {
      "type": "<class 'bspump.http.web.components.text_field.TextField'>",
      "description": ""
    }
  } 
}
```
An example web form now returns a cleaner formatted web form in json format 
```
curl -H "Content-Type: application/json" http://localhost:8080/?secret=sesame | jq
```
```
{
  "foo": {
    "type": "TextField",
    "description": "specify the foo"
  },
  "la": {
    "type": "TextField",
    "description": ""
  },
  "n": {
    "type": "IntField",
    "description": ""
  },
  "bar": {
    "type": "TextField",
    "description": ""
  },
  "hex": {
    "lol": {
      "type": "ChoiceField",
      "description": ""
    },
    "checkbox": {
      "type": "CheckboxField",
      "description": ""
    }
  }
}
```