### PR TITLE
Implemented error handler into Sink (and fixed a small typo)

### DIFF
--- a/bspump/abc/generator.py
+++ b/bspump/abc/generator.py
@@ -58,9 +58,11 @@ class Generator(ProcessorBase):
 
 
         """
-        self.Pipeline.ensure_future(
-            self.generate(context, event, self.PipelineDepth + 1)
-        )
+
+        async def _fn():
+            return await self.generate(context, event, self.PipelineDepth + 1)
+
+        self.Pipeline.ensure_future(_fn())
         return None
 
     async def generate(self, context, event, depth):

--- a/bspump/abc/generator.py
+++ b/bspump/abc/generator.py
@@ -49,6 +49,7 @@ class Generator(ProcessorBase):
         """
         Description:
 
+
         **Parameters**
 
         context :
@@ -58,11 +59,9 @@ class Generator(ProcessorBase):
 
 
         """
-
-        async def _fn():
-            return await self.generate(context, event, self.PipelineDepth + 1)
-
-        self.Pipeline.ensure_future(_fn())
+        self.Pipeline.ensure_future(
+            self.generate(context, event, self.PipelineDepth + 1)
+        )
         return None
 
     async def generate(self, context, event, depth):

--- a/bspump/abc/sink.py
+++ b/bspump/abc/sink.py
@@ -11,6 +11,3 @@ class Sink(ProcessorBase):
 
     def handle_error(self, context, event, exception, timestamp):
         raise exception
-
-    def _handle_error(self, context, event, exception, timestamp):
-        self.handle_error(context, event, exception, timestamp)

--- a/bspump/abc/sink.py
+++ b/bspump/abc/sink.py
@@ -9,5 +9,8 @@ class Sink(ProcessorBase):
 
     """
 
-    def handle_error(self, context, event, exception):
+    def handle_error(self, context, event, exception, timestamp):
         raise exception
+
+    def _handle_error(self, context, event, exception, timestamp):
+        self.handle_error(context, event, exception, timestamp)

--- a/bspump/abc/sink.py
+++ b/bspump/abc/sink.py
@@ -9,4 +9,5 @@ class Sink(ProcessorBase):
 
     """
 
-    pass
+    def handle_error(self, context, event, exception):
+        raise exception

--- a/bspump/http/web/components/base_field.py
+++ b/bspump/http/web/components/base_field.py
@@ -13,7 +13,7 @@ class BaseField:
     def html(self, defaults) -> str:
         pass
 
-    def get_params(defaults) -> dict:
+    def get_params(self) -> dict:
         pass
 
     def restructure_data(self, dfrom, dto):

--- a/bspump/http/web/server.py
+++ b/bspump/http/web/server.py
@@ -504,6 +504,10 @@ class JSONWebSink(Sink):
                 )
             )
 
+    def handle_error(self, context, event, exception):
+        print("JSONWebSink handle error")
+        raise exception
+
     def render_html_output(self, json_data):
         template = env.get_template("output-form.html")
         fields_html = self.format_json_to_html(json_data)

--- a/bspump/http/web/server.py
+++ b/bspump/http/web/server.py
@@ -502,7 +502,7 @@ class JSONWebSink(Sink):
     JSONWebSink is a sink that sends HTTP requests with JSON content.
     """
 
-    def handle_response(self, event):
+    def send_response(self, event):
         if expects_html(event["request"]):
             html_content = self.render_html_output(event["response"])
             event["response_future"].set_result(
@@ -521,7 +521,7 @@ class JSONWebSink(Sink):
         """
         Process the incoming event and respond with either JSON or HTML.
         """
-        self.handle_response(event)
+        self.send_response(event)
 
     def handle_error(self, context, event, exception, timestamp):
         """
@@ -530,7 +530,7 @@ class JSONWebSink(Sink):
         """
         event["status"] = 500
         event["response"] = {"error": "Internal Server Error"}
-        self.handle_response(event)
+        self.send_response(event)
 
     def render_html_output(self, json_data):
         template = env.get_template("output-form.html")

--- a/bspump/pipeline.py
+++ b/bspump/pipeline.py
@@ -650,6 +650,7 @@ class Pipeline(abc.ABC, bspump.asab.Configurable):
                 *_, sink = self.iter_processors()
                 context, event, _, timestamp = self._error
                 event = sink.handle_error(context, event, exception, timestamp)
+                self.set_error(context, event, exception)
                 self._error = None
             except Exception as e:
                 self.set_error(None, None, e)

--- a/bspump/pipeline.py
+++ b/bspump/pipeline.py
@@ -651,9 +651,7 @@ class Pipeline(abc.ABC, bspump.asab.Configurable):
                 context, event, _, timestamp = self._error
                 event = sink.handle_error(context, event, exception, timestamp)
                 self._error = None
-                L.warn(f"Error handled by sink {event}")
             except Exception as e:
-                L.error(f"Sink failed to handle {e}")
                 self.set_error(None, None, e)
 
     # Construction


### PR DESCRIPTION
Inherit from any Sink type and override for custom behavior to handle uncaught exceptions. Default behavior is re-raising, which uses normal pipeline error handling. For the JSONWebSink, the default behavior is to send a JSON or HTML result with "internal server error"