### PR TITLE
Fix/bitswan cli filters empty lines

### DIFF
--- a/bspump/main.py
+++ b/bspump/main.py
@@ -61,11 +61,10 @@ class NotebookCompiler:
 
                 clean_code = "\n".join(
                     [re.sub(r"^\t+(?=\S)", "", line) if not line.startswith("!") else "" for line in code.split("\n")]
-                ).rstrip("\n") + "\n"
+                ).strip("\n") + "\n"
 
                 if not clean_code.strip():
                     return
-
                 if not self._in_autopipeline:
                     fout.write(clean_code + "\n\n")
                 else:

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -59,9 +59,17 @@ class NotebookCompiler:
                     else cell["source"]
                 )
 
-                clean_code = "\n".join(
-                    [re.sub(r"^\t+(?=\S)", "", line) if not line.startswith("!") else "" for line in code.split("\n")]
-                ).strip("\n") + "\n"
+                clean_code = (
+                    "\n".join(
+                        [
+                            re.sub(r"^\t+(?=\S)", "", line)
+                            if not line.startswith("!")
+                            else ""
+                            for line in code.split("\n")
+                        ]
+                    ).strip("\n")
+                    + "\n"
+                )
 
                 if not clean_code.strip():
                     return

--- a/bspump/main.py
+++ b/bspump/main.py
@@ -58,13 +58,14 @@ class NotebookCompiler:
                     if isinstance(cell["source"], list)
                     else cell["source"]
                 )
-                clean_code = ""
-                for line in list(filter(None, code.split("\n"))):
-                    if line.startswith("!"):
-                        continue
-                    clean_code += re.sub(r"^\t+(?=\S)", "", line) + "\n"
-                if not clean_code:
+
+                clean_code = "\n".join(
+                    [re.sub(r"^\t+(?=\S)", "", line) if not line.startswith("!") else "" for line in code.split("\n")]
+                ).rstrip("\n") + "\n"
+
+                if not clean_code.strip():
                     return
+
                 if not self._in_autopipeline:
                     fout.write(clean_code + "\n\n")
                 else:


### PR DESCRIPTION
I modified the parse_cell function so it won't completely filter out the empty lines - it will preserve one empty line. I had the issue with markdown string
`

---
markdown_string = """
## Přehled

| Třída | ISIN     | NAVPS | FK |
|-------|----------|-------|----|
| PIA   | CZ123456 | 1,234 | 500,000 |
| PRIA  | CZ123457 | 1,567 | 700,000 |
| VIA   | CZ123458 | 5,125 | 900,000 |
| Celkem|          |       | 2,100,000 |

---

"""
`  
Empty lines in markdown determines if it is a table so I need to preserve them.
I checked it and the preserved empty lines should not create any issues in running of the code through bitswan-cli but I would appreciate a second check from you. 