### PR TITLE
terrible hack for vscode path

### DIFF
--- a/bspump/jupyter/__init__.py
+++ b/bspump/jupyter/__init__.py
@@ -1,19 +1,23 @@
 def vscode_secrets_fixme():
     from IPython import get_ipython
+
     ipy = get_ipython()
     if not ipy:
         return
     import re
     import os
+
     if "IPKernelApp" in ipy.config or "VSCODE_PID" in os.environ:
-        uri = ipy.get_parent()['metadata']['cellId']
+        uri = ipy.get_parent()["metadata"]["cellId"]
         match_ = re.match(r"vscode-notebook-cell://[^/]+(/.*?)/[^/]+\.ipynb", uri)
         if match_:
-            cleaned_path = match_.group(1) + '/'
+            cleaned_path = match_.group(1) + "/"
             os.chdir(cleaned_path)
+
+
 try:
     vscode_secrets_fixme()
-except:
+except Exception:
     pass
 
 from .jupyter import (

--- a/bspump/jupyter/__init__.py
+++ b/bspump/jupyter/__init__.py
@@ -1,3 +1,21 @@
+def vscode_secrets_fixme():
+    from IPython import get_ipython
+    ipy = get_ipython()
+    if not ipy:
+        return
+    import re
+    import os
+    if "IPKernelApp" in ipy.config or "VSCODE_PID" in os.environ:
+        uri = ipy.get_parent()['metadata']['cellId']
+        match_ = re.match(r"vscode-notebook-cell://[^/]+(/.*?)/[^/]+\.ipynb", uri)
+        if match_:
+            cleaned_path = match_.group(1) + '/'
+            os.chdir(cleaned_path)
+try:
+    vscode_secrets_fixme()
+except:
+    pass
+
 from .jupyter import (
     deploy,
     init_bitswan_jupyter,


### PR DESCRIPTION
Fixes the sudden undesirable behavior in the vscode web editor that jupyter notebooks are opened with the working directory `~/workspace`, as opposed to the directory of the automation