### PR TITLE
Replace pip with uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,13 @@ RUN apt-get -yqq install \
  build-essential \
  docker-compose
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 COPY . /src/
 
 RUN apt-get remove -y python3-yaml && apt-get autoremove -y
 
-RUN cd /src/ ; pip3 install .
+RUN cd /src/ && uv pip install --system .
 
 COPY pre/ /opt/
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You must first install the [bitswan workspaces](https://github.com/bitswan-space
 ```
 $ git clone git@github.com:bitswan-space/BitSwan.git
 $ cd BitSwan
+$ curl -LsSf https://astral.sh/uv/install.sh | sh
 $ python3 -m venv venv
 $ source venv/bin/activate
 $ pip3 install -e ".[dev]"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ You must first install the [bitswan workspaces](https://github.com/bitswan-space
 $ git clone git@github.com:bitswan-space/BitSwan.git
 $ cd BitSwan
 $ curl -LsSf https://astral.sh/uv/install.sh | sh
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip3 install -e ".[dev]"
+$ uv venv
+$ source .venv/bin/activate
+$ uv pip install -e ".[dev]"
 ```
 
 Running pipelines


### PR DESCRIPTION
This PR switches the Dockerfile and local setup instructions from pip to uv

### Changes:
- Dockerfile now installs `uv` from official image
- Replaces `pip3 install` with `uv pip install --system`
- README updated with `uv`