### PR TITLE
Protected Web Route Source method fix

### DIFF
--- a/bspump/http/web/server.py
+++ b/bspump/http/web/server.py
@@ -200,7 +200,9 @@ class ProtectedWebRouteSource(WebRouteSource):
                 )
                 return await response_future
 
-            return await gate_response(request, lambda secret: self.test_secret(secret), response_fn)
+            return await gate_response(
+                request, lambda secret: self.test_secret(secret), response_fn
+            )
         except Exception:
             L.exception("Exception in WebSource")
             return aiohttp.web.Response(status=500)


### PR DESCRIPTION
Method within `ProtectedWebRouteSource` expected to get function but we were passing variable to it instead. I made it so function which checks the secret is passed to it instead. Similarly to other classes which use `test_secret` method.