### PR TITLE
Fix English typos across source files, docs, tests, and examples

### DIFF
--- a/bspump/abc/anomaly.py
+++ b/bspump/abc/anomaly.py
@@ -1,6 +1,6 @@
 class Anomaly(dict):
     """
-    Description: 	Anomaly is an abstract class to be overriden for a specific anomaly and its type.
+    Description: 	Anomaly is an abstract class to be overridden for a specific anomaly and its type.
 
     :return:
 

--- a/bspump/abc/generator.py
+++ b/bspump/abc/generator.py
@@ -24,7 +24,7 @@ class Generator(ProcessorBase):
         id : str, default = None
                         ID
 
-        config : JSON, defualt = None
+        config : JSON, default = None
                         configuration file containing additional information.
 
         """

--- a/bspump/analyzer/analyzer.py
+++ b/bspump/analyzer/analyzer.py
@@ -101,7 +101,7 @@ class Analyzer(Processor):
 
     async def on_clock_tick(self):
         """
-        Run analyzis every tick.
+        Run analysis every tick.
 
         """
         t0 = time.perf_counter()

--- a/bspump/analyzer/sessionanalyzer.py
+++ b/bspump/analyzer/sessionanalyzer.py
@@ -39,7 +39,7 @@ class SessionAnalyzer(Analyzer):
             +------------+------------------+
 
     Example: 'i8' stands for int64.
-    Important! However it is possible to use all these letters, it is recommeded to use only 'i' for integers, 'f' for
+    Important! However it is possible to use all these letters, it is recommended to use only 'i' for integers, 'f' for
     floats, 'U' for strings. Anything else might cause problems in serialization.
     It is possible to create a matrix with elements of specified format. The tuple with number of dimensions should
     stand before the letter.
@@ -77,9 +77,9 @@ class SessionAnalyzer(Analyzer):
 
         analyze_on_clock : bool, default = False
 
-        persistent : bool, defualt = False
+        persistent : bool, default = False
 
-        id : str, defualt = None
+        id : str, default = None
 
         config : JSON, default = None
                 configuration file with additional information.

--- a/bspump/analyzer/threshold.py
+++ b/bspump/analyzer/threshold.py
@@ -22,11 +22,11 @@ class ThresholdAnalyzer(TimeWindowAnalyzer):
             evaluate method - Take event attributes and sorts them into the matrix
 
             analyze method - Check whether any value in the matrix is over the preconfigured bounds and if so, check the
-                                            occurrance of the symptom in the array and then possibly call the alarm.
+                                            occurrence of the symptom in the array and then possibly call the alarm.
                                             To analyze, whether the values are out of bounds, the 'np.where()' method is used. It pass the
                                             position of values out of bounds within the matrix to the alarm method.
                                             x = row position, y = column position
-                                            To detect whether the symptom occurrance of the 'values out of bounds' is higher or equal, than number
+                                            To detect whether the symptom occurrence of the 'values out of bounds' is higher or equal, than number
                                             set in the configuration, an aggregation is used. Result of aggregation is the number of occurrences
                                             and indices of those values. It is then passed to the alarm method together with x and y arrays.
 
@@ -176,7 +176,7 @@ class ThresholdAnalyzer(TimeWindowAnalyzer):
 
         # Symptom occurrence detection
         try:
-            # Setting previous value. When it is empty, further computation wont proceed.
+            # Setting previous value. When it is empty, further computation won't proceed.
             previous = x[0]
         except IndexError:
             return

--- a/bspump/analyzer/timedriftanalyzer.py
+++ b/bspump/analyzer/timedriftanalyzer.py
@@ -14,8 +14,8 @@ L = logging.getLogger(__name__)
 class TimeDriftAnalyzer(Analyzer):
     """
     The analyzer, which shows how different is time of the stream from the current time.
-    The output of the analyzis is a metric with average time, median time, minimum time,
-    maximum time and a standart deviation.
+    The output of the analysis is a metric with average time, median time, minimum time,
+    maximum time and a standard deviation.
 
     **Default Config**
 

--- a/bspump/analyzer/timewindowanalyzer.py
+++ b/bspump/analyzer/timewindowanalyzer.py
@@ -13,7 +13,7 @@ L = logging.getLogger(__name__)
 class TimeWindowAnalyzer(Analyzer):
     """
     This is the analyzer for events with a temporal dimension (aka timestamp).
-    Configurable sliding window records events withing specified windows and implements functions to find the exact time slot.
+    Configurable sliding window records events within specified windows and implements functions to find the exact time slot.
     Timer periodically shifts the window by time window resolution, dropping previous events.
 
     `TimeWindowAnalyzer` operates over the `TimeWindowMatrix` object.
@@ -23,10 +23,10 @@ class TimeWindowAnalyzer(Analyzer):
     `clock_driven` is a boolean parameter, specifying how the matrix should be advanced. If `True`, it advances on timer's tick,
     else manually. Default value is `True`.
     `matrix_id` is an id of `TimeWindowMatrix` object alternatively passed, if not provided, the new matrix will be created with and ID derived from the Analyzer Id
-    `analyze_on_clock` enables enables analyzis by timer.
+    `analyze_on_clock` enables enables analysis by timer.
 
     If the `TimeWindowAnalyzer` is `clock_driven`, the time should be periodically shifted (`on_clock_tick()`). The same
-    function runs analyzis, if it's enabled.
+    function runs analysis, if it's enabled.
     """
 
     def __init__(

--- a/bspump/asab/alert.py
+++ b/bspump/asab/alert.py
@@ -237,7 +237,7 @@ class AlertService(Service):
                 "asab:alert:sentry": SentryAlertProvider,
             }.get(section)
             if provider_cls is None:
-                L.warning("Unknwn alert provider: {}".format(section))
+                L.warning("Unknown alert provider: {}".format(section))
                 continue
 
             self.Providers.append(

--- a/bspump/asab/api/discovery.py
+++ b/bspump/asab/api/discovery.py
@@ -122,7 +122,7 @@ class DiscoveryService(Service):
         Usage:
 
         async with self.DiscoveryService.session() as session:
-                # use URL in format: <protocol>://<value>.<key>.asab/<endpoint> where key is "service_id" or "instance_id" and value the respective serivce identificator
+                # use URL in format: <protocol>://<value>.<key>.asab/<endpoint> where key is "service_id" or "instance_id" and value the respective service identificator
                 async with session.get("http://my_application_1.instance_id.asab/asab/v1/config") as resp:
                         ...
         """

--- a/bspump/asab/api/service.py
+++ b/bspump/asab/api/service.py
@@ -149,7 +149,7 @@ class ApiService(Service):
         ```
 
 
-        Intialize with a custom Zookeeper container:
+        Initialize with a custom Zookeeper container:
 
         ```
         zksvc = self.App.get_service("asab.ZooKeeperService")

--- a/bspump/asab/application.py
+++ b/bspump/asab/application.py
@@ -722,7 +722,7 @@ class Application(metaclass=Singleton):
         This method ensures that any newly add module or registered service is initialized.
         It is called from:
         (1) init-time for modules&services added during application construction.
-        (2) run-time for modules&services added during aplication lifecycle.
+        (2) run-time for modules&services added during application lifecycle.
         """
 
         # Initialize modules

--- a/bspump/asab/library/providers/git.py
+++ b/bspump/asab/library/providers/git.py
@@ -198,7 +198,7 @@ class GitLibraryProvider(FileSystemLibraryProvider):
         if new_commit_id == self.GitRepository.head.target:
             return []
 
-        # Before new head is set, check the diffs. If changes in subscribed directory occured, add path to "to_publish" list.
+        # Before new head is set, check the diffs. If changes in subscribed directory occurred, add path to "to_publish" list.
         to_publish = []
         for path in self.SubscribedPaths:
             for i in self.GitRepository.diff(

--- a/bspump/asab/log.py
+++ b/bspump/asab/log.py
@@ -413,7 +413,7 @@ class StructuredDataFormatter(logging.Formatter):
 def _loop_exception_handler(loop, context):
     """
     This is an logging exception handler for asyncio.
-    It's purpose is to nicely log any unhandled excpetion that arises in the asyncio tasks.
+    It's purpose is to nicely log any unhandled exception that arises in the asyncio tasks.
     """
 
     exception = context.pop("exception", None)

--- a/bspump/asab/metrics/openmetric.py
+++ b/bspump/asab/metrics/openmetric.py
@@ -1,6 +1,6 @@
 import re
 
-# HOW TO FULLFIL OPEMETRICS STANDARD
+# HOW TO FULFILL OPENMETRICS STANDARD
 
 # Metrics SHOULD have "unit" and "help" Tags
 # Help is a string and SHOULD be non-empty. It is used to give a brief description of the MetricFamily for human consumption and SHOULD be short enough to be used as a tooltip.

--- a/bspump/asab/metrics/storage.py
+++ b/bspump/asab/metrics/storage.py
@@ -24,7 +24,7 @@ class Storage(object):
             # It is designed to support e.g. dynamic prebuilds of the classes with the same metrics.
             # In other cases, this path should be avoided by e.g. creation of metrics in init time, not during runtime
             L.debug(
-                "The metrics storage '{}/{}' is overriden".format(metric_name, tags)
+                "The metrics storage '{}/{}' is overridden".format(metric_name, tags)
             )
             del self.Metrics[i]
 

--- a/bspump/asab/zookeeper/container.py
+++ b/bspump/asab/zookeeper/container.py
@@ -106,7 +106,7 @@ class ZooKeeperContainer(Configurable):
 
         self.Path = url_path
 
-        self.Advertisments = dict()
+        self.Advertisements = dict()
         self.DataWatchers = set()
         self.App.PubSub.subscribe("Application.tick/300!", self._readvertise)
 
@@ -167,14 +167,14 @@ class ZooKeeperContainer(Configurable):
     # Advertisement into Zookeeper
 
     def advertise(self, data, path):
-        adv = self.Advertisments.get(self.Path + path)
+        adv = self.Advertisements.get(self.Path + path)
         if adv is None:
             adv = ZooKeeperAdvertisement(self.Path + path)
-            self.Advertisments[self.Path + path] = adv
+            self.Advertisements[self.Path + path] = adv
         self.App.TaskService.schedule(adv._set_data(self, data))
 
     async def _readvertise(self, *args):
-        for adv in self.Advertisments.values():
+        for adv in self.Advertisements.values():
             await adv._readvertise(self)
 
     # Reading

--- a/bspump/common/routing.py
+++ b/bspump/common/routing.py
@@ -101,7 +101,7 @@ class InternalSource(Source):
 
         If you are getting a `asyncio.queues.QueueFull` exception,
         you likely did not implemented backpressure handling.
-        The simpliest approach is to use RouterSink / RouterProcessor.
+        The simplest approach is to use RouterSink / RouterProcessor.
 
         |
 

--- a/bspump/declarative/builder.py
+++ b/bspump/declarative/builder.py
@@ -316,7 +316,7 @@ class ExpressionBuilder(object):
                 value = float(node.value)
             else:
                 raise NotImplementedError(
-                    "Unsupport scalar type '{}'".format(outlet_type)
+                    "Unsupported scalar type '{}'".format(outlet_type)
                 )
             obj = VALUE(self.App, value=value, outlet_type=outlet_type)
 

--- a/bspump/declarative/expression/datastructs/itemexpr.py
+++ b/bspump/declarative/expression/datastructs/itemexpr.py
@@ -91,11 +91,11 @@ class ITEM(Expression):
         return None
 
     def __call__(self, context, event, *args, **kwargs):
-        wth = self.With(context, event, *args, **kwargs)
+        with = self.With(context, event, *args, **kwargs)
         item = self.Item(context, event, *args, **kwargs)
 
         try:
-            return wth[item]
+            return with[item]
 
         except (KeyError, IndexError):
             if self.Default is None:

--- a/bspump/declarative/expression/datastructs/itemexpr.py
+++ b/bspump/declarative/expression/datastructs/itemexpr.py
@@ -91,11 +91,11 @@ class ITEM(Expression):
         return None
 
     def __call__(self, context, event, *args, **kwargs):
-        with = self.With(context, event, *args, **kwargs)
+        container = self.With(context, event, *args, **kwargs)
         item = self.Item(context, event, *args, **kwargs)
 
         try:
-            return with[item]
+            return container[item]
 
         except (KeyError, IndexError):
             if self.Default is None:

--- a/bspump/declarative/expression/logical.py
+++ b/bspump/declarative/expression/logical.py
@@ -5,7 +5,7 @@ from .value.valueexpr import VALUE
 
 class AND(SequenceExpression):
     """
-    Checks if all expressions are true, respectivelly, stop on the first False
+    Checks if all expressions are true, respectively, stop on the first False
     """
 
     Attributes = {"Items": ["bool"]}

--- a/bspump/declarative/expression/string/cutexpr.py
+++ b/bspump/declarative/expression/string/cutexpr.py
@@ -44,7 +44,7 @@ class CUT(Expression):
 
         except Exception as e:
             L.exception(
-                "The following exception ocurred in !CUT expression [delimiter: {}, field: {}]".format(
+                "The following exception occurred in !CUT expression [delimiter: {}, field: {}]".format(
                     self.Delimiter, self.Field
                 )
             )

--- a/bspump/declarative/expression/string/joinexpr.py
+++ b/bspump/declarative/expression/string/joinexpr.py
@@ -71,7 +71,7 @@ class JOIN(Expression):
 
         except Exception as e:
             L.exception(
-                "The following exception ocurred in !JOIN expression [delimiter: {}]".format(
+                "The following exception occurred in !JOIN expression [delimiter: {}]".format(
                     self.Char
                 )
             )

--- a/bspump/declarative/expression/string/regex.py
+++ b/bspump/declarative/expression/string/regex.py
@@ -46,7 +46,7 @@ class REGEX(Expression):
 
 class REGEX_PARSE(Expression):
     """
-    Search `value` forr `regex` with regular expressions groups.
+    Search `value` for `regex` with regular expressions groups.
     If nothing is found `miss` is returned.
     Otherwise, groups are returned in as a list.
 

--- a/bspump/declarative/optimizer.py
+++ b/bspump/declarative/optimizer.py
@@ -50,7 +50,7 @@ class ExpressionOptimizer(object):
 
                 if counter > 100000:
                     raise RuntimeError(
-                        "Optimization likely stucked at '{}'-'{}'-'{}'/'{}'".format(
+                        "Optimization likely stuck at '{}'-'{}'-'{}'/'{}'".format(
                             parent, key, obj, opt_obj
                         )
                     )

--- a/bspump/declarative/segmentbuilder.py
+++ b/bspump/declarative/segmentbuilder.py
@@ -86,7 +86,7 @@ class SegmentBuilder(object):
     def register_processor(self, processor_keyword, _module, _class):
         """
         Registers custom processors that are translated to module & class.
-        The default keywords may also be overriden.
+        The default keywords may also be overridden.
         """
         self.PROCESSORS[processor_keyword] = (_module, _class)
 

--- a/bspump/elasticsearch/connection.py
+++ b/bspump/elasticsearch/connection.py
@@ -85,7 +85,7 @@ class ElasticSearchBulk(object):
                         ?
 
         timeout : int
-                        uses timout value from config. Value of time for how long we want to be connected to ElasticSearch.
+                        uses timeout value from config. Value of time for how long we want to be connected to ElasticSearch.
 
         :return: ?
 
@@ -240,7 +240,7 @@ class ElasticSearchConnection(Connection):
                     ??
 
     timeout : int, default = 300
-                    Timout value.
+                    Timeout value.
 
     fail_log_max_size : int, default =  20
                     Maximum size of failed log messages.
@@ -455,7 +455,7 @@ class ElasticSearchConnection(Connection):
 
                 self._futures[i] = (url, None)
 
-            # 2) Start _loader() futures that are exitted
+            # 2) Start _loader() futures that are exited
             if self._started:
                 url, future = self._futures[i]
                 if future is None:
@@ -549,8 +549,8 @@ class ElasticSearchConnection(Connection):
                 if self._output_queue.qsize() == self._output_queue_max_size - 1:
                     self.PubSub.publish("ElasticSearchConnection.unpause!", self)
 
-                sucess = await bulk.upload(url, session, self._timeout)
-                if not sucess:
+                success = await bulk.upload(url, session, self._timeout)
+                if not success:
                     # Requeue the bulk for another delivery attempt to ES
                     self.enqueue(bulk)
                     await asyncio.sleep(5)  # Throttle a bit before next try

--- a/bspump/file/fileabcsource.py
+++ b/bspump/file/fileabcsource.py
@@ -239,7 +239,7 @@ class FileABCSource(TriggerSource):
         finally:
             f.close()
 
-        L.debug("File '{}' processed {}".format(filename, "succefully"))
+        L.debug("File '{}' processed {}".format(filename, "successfully"))
 
         # Finalize
         try:

--- a/bspump/filter/attributefilter.py
+++ b/bspump/filter/attributefilter.py
@@ -11,7 +11,7 @@ L = logging.getLogger(__name__)
 
 class AttributeFilter(Processor):
     """
-    This is processor implenting a simple attribute filter.
+    This is processor implementing a simple attribute filter.
     If 'inclusive' is False, all fields from event matching with lookup will be deleted,
     otherwise all fields not from lookup will be deleted from event.
     """

--- a/bspump/filter/contentfilter.py
+++ b/bspump/filter/contentfilter.py
@@ -13,7 +13,7 @@ L = logging.getLogger(__name__)
 
 class ContentFilter(Processor):
     """
-    This is processor implenting a simple attribute filter.
+    This is processor implementing a simple attribute filter.
     The query is constructed in mongodb manner.
     NB:
     Only the "/pattern/<options>" syntax is supported for $regex.
@@ -42,14 +42,14 @@ class ContentFilter(Processor):
 
     def on_hit(self, context, event):
         """
-        This function tranforms the event, if it
+        This function transforms the event, if it
         matched the query.
         """
         return event
 
     def on_miss(self, context, event):
         """
-        This function tranforms the event, if it did not
+        This function transforms the event, if it did not
         matched the query.
         """
         return event

--- a/bspump/ftp/source.py
+++ b/bspump/ftp/source.py
@@ -65,7 +65,7 @@ class FTPSource(TriggerSource):
         if self.Queue.qsize() == 0:
             self.list_future = None
 
-        # conenct to the client
+        # connect to the client
         self.client = await self.Connection.connect()
 
         # if the filename is specified then add only filename to queue else add the

--- a/bspump/googledrive/abcsink.py
+++ b/bspump/googledrive/abcsink.py
@@ -11,7 +11,7 @@ L = logging.getLogger(__name__)
 
 class GoogleDriveABCSink(Sink):
     """
-    GoogleDriveABCSink is abstract class ment to be used for uploading files to GoogleDrive.
+    GoogleDriveABCSink is abstract class meant to be used for uploading files to GoogleDrive.
     """
 
     def __init__(self, app, pipeline, connection, id=None, config=None):

--- a/bspump/googledrive/connection.py
+++ b/bspump/googledrive/connection.py
@@ -20,12 +20,12 @@ class GoogleDriveConnection(Connection):
     This connection is synchronous and therefore all connectors using it
     are blocking.
 
-    To aquire service_account_file, you will need to go to console.developers.google.com and create service account.
+    To acquire service_account_file, you will need to go to console.developers.google.com and create service account.
     Create a private key for your service account and download json private key file.
     The process is well documented here https://developers.google.com/identity/protocols/OAuth2ServiceAccount .
     Then it is necessary to delegate authority over a client account to created
     service account. You can do it in admin console: https://admin.google.com/
-    For more details refere to the link above.
+    For more details refer to the link above.
 
     For the delegation, G Suite domain administrator console is necessary.
     Free Google accounts can't be used as target of Google Drive connection.

--- a/bspump/influxdb/connection.py
+++ b/bspump/influxdb/connection.py
@@ -40,7 +40,7 @@ class InfluxDBConnection(Connection):
 
             output_bucket_max_size : 1000 * 1000
 
-            timout : 30
+            timeout : 30
 
             retry_enabled : False
 
@@ -191,7 +191,7 @@ class InfluxDBConnection(Connection):
                             and self.RetryEnabled
                         ):
                             L.warning(
-                                f"Retryable response code recieved, retrying. Queue size {self._output_queue.qsize()}"
+                                f"Retryable response code received, retrying. Queue size {self._output_queue.qsize()}"
                             )
                             self._output_queue.put_nowait(_output_bucket)
                             self.PubSub.publish("InfluxDBConnection.pause!", self)

--- a/bspump/kafka/sink.py
+++ b/bspump/kafka/sink.py
@@ -33,7 +33,7 @@ class KafkaSink(Sink):
 
             There are two ways to use KafkaSink:
             - Specify a single topic in KafkaSink config - topic, to be used for all the events in pipeline.
-            - Specify topic separetly for each event in event context - context['kafka_topic'].
+            - Specify topic separately for each event in event context - context['kafka_topic'].
                             Topic from configuration is than used as a default topic.
                             To provide business logic for event distribution, you can create topic selector processor.
             Processor example:
@@ -65,7 +65,7 @@ class KafkaSink(Sink):
         "watermark.low": "40000",
         "watermark.high": "90000",
         "batch.num.messages": "100000",
-        "linger.ms": "500",  # This settings makes a significant impact on the throughtput
+        "linger.ms": "500",  # This settings makes a significant impact on the throughput
         "batch.size": "1000000",
         "poll.timeout": "0.2",
         # "compression.type": "snappy",

--- a/bspump/kafka/source.py
+++ b/bspump/kafka/source.py
@@ -155,7 +155,7 @@ class KafkaSource(Source):
 
                     if m.error():
                         L.error(
-                            "The following error occured while polling for messages: '{}'.".format(
+                            "The following error occurred while polling for messages: '{}'.".format(
                                 m.error()
                             )
                         )

--- a/bspump/lookup/index.py
+++ b/bspump/lookup/index.py
@@ -30,7 +30,7 @@ class Index(object):
 class BitMapIndex(Index):
     def __init__(self, column, matrix, id=None):
         """
-        Make sure, that column values are discreet.
+        Make sure, that column values are discrete.
         Also the creation procedure is relatively slow.
         """
         super().__init__(id=id)

--- a/bspump/lookup/memcachedlookup.py
+++ b/bspump/lookup/memcachedlookup.py
@@ -48,4 +48,4 @@ class MemcachedLookup(Lookup):
 
     def flush_all(self):
         self.Client.flush_all()
-        L.info("Chache flushed")
+        L.info("Cache flushed")

--- a/bspump/matrix/matrix.py
+++ b/bspump/matrix/matrix.py
@@ -17,7 +17,7 @@ class Matrix(abc.ABC, Configurable):
     """
     Generic `Matrix` object.
 
-    Matrix structure is organized in a following hiearchical order:
+    Matrix structure is organized in a following hierarchical order:
 
     Matrix -> Rows -> Columns -> Cells
 
@@ -152,14 +152,14 @@ class Matrix(abc.ABC, Configurable):
         """
         The `Matrix` itself can run the `analyze()`.
         It is not recommended to iterate through the matrix row by row (or cell by cell).
-        Instead use numpy fuctions. Examples:
-        1. You have a vector with n rows. You need only those row indeces, where the cell content is more than 10.
+        Instead use numpy functions. Examples:
+        1. You have a vector with n rows. You need only those row indices, where the cell content is more than 10.
         Use `np.where(vector > 10)`.
         2. You have a matrix with n rows and m columns. You need to find out which rows
         fully consist of zeros. use `np.where(np.all(matrix == 0, axis=1))` to get those row indexes.
         Instead `np.all()` you can use `np.any()` to get all row indexes, where there is at least one zero.
         3. Use `np.mean(matrix, axis=1)` to get means for all rows.
-        4. Usefull numpy functions: `np.unique()`, `np.sum()`, `np.argmin()`, `np.argmax()`.
+        4. Useful numpy functions: `np.unique()`, `np.sum()`, `np.argmin()`, `np.argmax()`.
         """
         pass
 

--- a/bspump/mongodb/changestreamsource.py
+++ b/bspump/mongodb/changestreamsource.py
@@ -65,7 +65,7 @@ class MongoDBChangeStreamSource(Source):
 
             except asyncio.CancelledError as e:
                 L.warning(
-                    f"Mongo change stream task cancled or timed out: {e}. Restarting connection."
+                    f"Mongo change stream task canceled or timed out: {e}. Restarting connection."
                 )
                 return await self.main()
             except pymongo.errors.OperationFailure as e:

--- a/bspump/mongodb/source.py
+++ b/bspump/mongodb/source.py
@@ -55,7 +55,7 @@ class MongoDBSource(TriggerSource):
         coll = db[self.Collection]
         await self.Pipeline.ready()
 
-        # query parms
+        # query params
         q_filter = self.QueryParms.get("filter", None)
         q_projection = self.QueryParms.get("projection", None)
         q_limit = self.QueryParms.get("limit", 0)

--- a/bspump/mysql/convertors.py
+++ b/bspump/mysql/convertors.py
@@ -1,7 +1,7 @@
 from pymysql.converters import encoders as convertors
 import numpy as np
 
-""" Those methods extends pymysql convertor for numpy datatypes """
+""" Those methods extends pymysql converter for numpy datatypes """
 
 
 def convert_numpy_int(value, mapping=None):

--- a/bspump/pipeline.py
+++ b/bspump/pipeline.py
@@ -390,7 +390,7 @@ class Pipeline(abc.ABC, bspump.asab.Configurable):
         who : ID of a :meth:`processor <bspump.Processor()>`.
                         Name of a :meth:`processor <bspump.Processor()>` that we want to throttle.
 
-        enable : bool, defualt True
+        enable : bool, default True
                         When True, content of argument 'who' is added to _throttles list.
 
 
@@ -989,7 +989,7 @@ class PipelineLogger(logging.Logger):
 
     def __init__(self, name, metrics_counter, level=logging.NOTSET):
         """
-        Itialize a metrics counter.
+        Initialize a metrics counter.
 
 
         """

--- a/bspump/postgresql/connection.py
+++ b/bspump/postgresql/connection.py
@@ -185,7 +185,7 @@ class PostgreSQLConnection(Connection):
                 return None
             raise e
         except BaseException as e:
-            L.exception("Unexpected PostgresSQL connection error. %s" % e)
+            L.exception("Unexpected PostgreSQL connection error. %s" % e)
             raise
 
     def acquire(self) -> aiopg.pool._PoolConnectionContextManager:

--- a/bspump/trigger/opportunistic.py
+++ b/bspump/trigger/opportunistic.py
@@ -4,7 +4,7 @@ from .trigger import Trigger
 class OpportunisticTrigger(Trigger):
     """
     This trigger tries to trigger the pump as frequenty as possible.
-    It triggers immediatelly when possible, after each Source report completed cycle and in 5 sec. period (see chilldown period)
+    It triggers immediately when possible, after each Source report completed cycle and in 5 sec. period (see chilldown period)
     """
 
     def __init__(self, app, id=None, run_immediately=True, chilldown_period=5):

--- a/doc/mqtt-metrics-and-visibility.md
+++ b/doc/mqtt-metrics-and-visibility.md
@@ -8,7 +8,7 @@ The MPIOP provides a set of MQTT topics which can be used to inspect (and in the
 Send `get` as the payload to:
 `c/{container_id}/topology/get`
 
-You will recieve the topology by subscribing to:
+You will receive the topology by subscribing to:
 
 `c/{container_id}/topology`
 
@@ -17,7 +17,7 @@ You will recieve the topology by subscribing to:
 Send `get` as the payload to:
 `c/{container_id}/c/{pipeline_id}/topology/get`
 
-You will recieve the topology by subscribing to:
+You will receive the topology by subscribing to:
 
 `c/{container_id}/c/{pipeline_id}/topology`
 

--- a/examples/AutoPipeline/main.ipynb
+++ b/examples/AutoPipeline/main.ipynb
@@ -109,7 +109,7 @@
     "\n",
     "----------------\n",
     "### Pipeline Definition (```auto_pipeline```)\n",
-    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specifiy the source and sink for our pipeline at this time."
+    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specify the source and sink for our pipeline at this time."
    ]
   },
   {
@@ -189,7 +189,7 @@
     "----------------\n",
     "### Testing\n",
     "You can run the notebook yourself by typing: ```bitswan notebook AutoPipeline/main.ipynb``` This will connect us to Kafka, and if we send events to Kafka, we’ll be able to see them flow through the pipeline.\n",
-    "Alternativelly, you can just test it directly in the notebook by Executing cells with different events."
+    "Alternatively, you can just test it directly in the notebook by Executing cells with different events."
    ]
   }
  ],

--- a/examples/ProtectedWebForm/main.ipynb
+++ b/examples/ProtectedWebForm/main.ipynb
@@ -8,7 +8,7 @@
     "Protected web forms\n",
     "-------------------\n",
     "\n",
-    "You can protect a webform with a secret key. This is usefull for debugging a JSON endpoint as this webform will also function as a normal REST endpoint that you can post JSON to. The advantage here, is that you can open it up in the browser with the secret key and play with it. This type of form should not be used for production as a URL containing a secret key can easilly be leaked thus compromising the security of the endpoint."
+    "You can protect a webform with a secret key. This is useful for debugging a JSON endpoint as this webform will also function as a normal REST endpoint that you can post JSON to. The advantage here, is that you can open it up in the browser with the secret key and play with it. This type of form should not be used for production as a URL containing a secret key can easily be leaked thus compromising the security of the endpoint."
    ]
   },
   {

--- a/examples/StocksCalculator/main.ipynb
+++ b/examples/StocksCalculator/main.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "Stock Calculator Automation\n",
     "----------------\n",
-    "This automation allows you to create a simple webpage with an input form that allows to select a date and when submitted, you see a higest rising stock from a selected set of stocks. \n"
+    "This automation allows you to create a simple webpage with an input form that allows to select a date and when submitted, you see a highest rising stock from a selected set of stocks. \n"
    ]
   },
   {

--- a/examples/Testing/ExpectError/main.ipynb
+++ b/examples/Testing/ExpectError/main.ipynb
@@ -84,7 +84,7 @@
    "id": "557e9886-316a-4ec9-88b7-688baec9433e",
    "metadata": {},
    "source": [
-    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specifiy the source and sink for our pipeline at this time."
+    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specify the source and sink for our pipeline at this time."
    ]
   },
   {

--- a/examples/Testing/InspectError/main.ipynb
+++ b/examples/Testing/InspectError/main.ipynb
@@ -84,7 +84,7 @@
    "id": "557e9886-316a-4ec9-88b7-688baec9433e",
    "metadata": {},
    "source": [
-    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specifiy the source and sink for our pipeline at this time."
+    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specify the source and sink for our pipeline at this time."
    ]
   },
   {

--- a/examples/Testing/MultiplePipelines/main.ipynb
+++ b/examples/Testing/MultiplePipelines/main.ipynb
@@ -84,7 +84,7 @@
    "id": "557e9886-316a-4ec9-88b7-688baec9433e",
    "metadata": {},
    "source": [
-    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specifiy the source and sink for our pipeline at this time."
+    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specify the source and sink for our pipeline at this time."
    ]
   },
   {

--- a/examples/Testing/ProbeError/main.ipynb
+++ b/examples/Testing/ProbeError/main.ipynb
@@ -84,7 +84,7 @@
    "id": "557e9886-316a-4ec9-88b7-688baec9433e",
    "metadata": {},
    "source": [
-    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specifiy the source and sink for our pipeline at this time."
+    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specify the source and sink for our pipeline at this time."
    ]
   },
   {

--- a/examples/Testing/main.ipynb
+++ b/examples/Testing/main.ipynb
@@ -84,7 +84,7 @@
    "id": "557e9886-316a-4ec9-88b7-688baec9433e",
    "metadata": {},
    "source": [
-    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specifiy the source and sink for our pipeline at this time."
+    "We use `auto_pipeline` to mark the start of the *pipeline section*. We also specify the source and sink for our pipeline at this time."
    ]
   },
   {

--- a/test/declarative/test_datetime_add.yaml
+++ b/test/declarative/test_datetime_add.yaml
@@ -1,6 +1,6 @@
 ---
 !ADD
-- 1 # Add a one second to the date/time from bellow
+- 1 # Add a one second to the date/time from below
 - !DATETIME.PARSE
   what: "1970-01-01 00:00:01"
   format: "%Y-%m-%d %H:%M:%S"

--- a/test/declarative/test_declarative_when.py
+++ b/test/declarative/test_declarative_when.py
@@ -27,7 +27,7 @@ class TestDeclarativeWhen(bspump.unittest.TestCase):
     def test_when_01_range(self):
         decl = self.load("./test_when.yaml")
         res = decl({}, {"key": 45})
-        self.assertEqual(res, "fourty to fifty (exclusive)")
+        self.assertEqual(res, "forty to fifty (exclusive)")
 
     def test_when_01_set(self):
         decl = self.load("./test_when.yaml")

--- a/test/declarative/test_when.yaml
+++ b/test/declarative/test_when.yaml
@@ -16,7 +16,7 @@
     - !ITEM EVENT key
     - 50
   then:
-    "fourty to fifty (exclusive)"
+    "forty to fifty (exclusive)"
 
 # In-set match
 - test:


### PR DESCRIPTION
56 files corrected using codespell; covers misspellings in comments, docstrings, log messages, and markdown (e.g. defualt→default, analyzis→analysis, ocurred→occurred, Advertisments→Advertisements).