### PR TITLE
fix: prevent 15-min logout in InternalApp examples by proactively refreshing the access token

### DIFF
--- a/examples/BitSwanInternalAppGolang/internal-frontend/src/App.tsx
+++ b/examples/BitSwanInternalAppGolang/internal-frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { backend, getUserInfo, getAccessToken, getImageUrl, getTokenInfo, type UserInfo, type TokenInfo } from './api'
+import { backend, getUserInfo, getAccessToken, refreshAccessToken, getImageUrl, getTokenInfo, type UserInfo, type TokenInfo } from './api'
 import './App.css'
 
 interface RootResponse {
@@ -93,6 +93,22 @@ function App() {
     }, 1000)
     return () => clearInterval(interval)
   }, [])
+
+  // Proactively refresh the access token ~60s before it expires. Without this,
+  // the cached JWT goes stale at the 15m Keycloak access-token TTL and the
+  // oauth2-proxy session cookie isn't pinged often enough to trigger the
+  // 14m cookie_refresh, so the user gets bounced back to login.
+  const expiryEpoch = tokenInfo?.expiresAt.getTime()
+  useEffect(() => {
+    if (expiryEpoch == null) return
+    const refreshInMs = Math.max(0, expiryEpoch - Date.now() - 60_000)
+    const timer = setTimeout(() => {
+      refreshAccessToken()
+        .then(() => setTokenInfo(getTokenInfo()))
+        .catch(err => console.error('Failed to refresh access token:', err))
+    }, refreshInMs)
+    return () => clearTimeout(timer)
+  }, [expiryEpoch])
 
   const incrementCount = async () => {
     try {

--- a/examples/BitSwanInternalAppGolang/internal-frontend/src/api.ts
+++ b/examples/BitSwanInternalAppGolang/internal-frontend/src/api.ts
@@ -58,6 +58,14 @@ export async function getAccessToken(): Promise<string> {
   return fetchAccessToken()
 }
 
+// Force a re-fetch from /oauth2/auth. Calling this while the oauth2-proxy
+// cookie is older than OAUTH2_PROXY_COOKIE_REFRESH (14m) causes oauth2-proxy
+// to refresh the Keycloak session, so it doubles as a keep-alive.
+export async function refreshAccessToken(): Promise<string> {
+  cachedToken = null
+  return fetchAccessToken()
+}
+
 export interface TokenInfo {
   expiresAt: Date
   issuedAt: Date

--- a/examples/BitSwanInternalAppPythonFastapi/internal-frontend/src/App.tsx
+++ b/examples/BitSwanInternalAppPythonFastapi/internal-frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { backend, getUserInfo, getAccessToken, getImageUrl, getTokenInfo, type UserInfo, type TokenInfo } from './api'
+import { backend, getUserInfo, getAccessToken, refreshAccessToken, getImageUrl, getTokenInfo, type UserInfo, type TokenInfo } from './api'
 import './App.css'
 
 interface RootResponse {
@@ -93,6 +93,22 @@ function App() {
     }, 1000)
     return () => clearInterval(interval)
   }, [])
+
+  // Proactively refresh the access token ~60s before it expires. Without this,
+  // the cached JWT goes stale at the 15m Keycloak access-token TTL and the
+  // oauth2-proxy session cookie isn't pinged often enough to trigger the
+  // 14m cookie_refresh, so the user gets bounced back to login.
+  const expiryEpoch = tokenInfo?.expiresAt.getTime()
+  useEffect(() => {
+    if (expiryEpoch == null) return
+    const refreshInMs = Math.max(0, expiryEpoch - Date.now() - 60_000)
+    const timer = setTimeout(() => {
+      refreshAccessToken()
+        .then(() => setTokenInfo(getTokenInfo()))
+        .catch(err => console.error('Failed to refresh access token:', err))
+    }, refreshInMs)
+    return () => clearTimeout(timer)
+  }, [expiryEpoch])
 
   const incrementCount = async () => {
     try {

--- a/examples/BitSwanInternalAppPythonFastapi/internal-frontend/src/api.ts
+++ b/examples/BitSwanInternalAppPythonFastapi/internal-frontend/src/api.ts
@@ -58,6 +58,14 @@ export async function getAccessToken(): Promise<string> {
   return fetchAccessToken()
 }
 
+// Force a re-fetch from /oauth2/auth. Calling this while the oauth2-proxy
+// cookie is older than OAUTH2_PROXY_COOKIE_REFRESH (14m) causes oauth2-proxy
+// to refresh the Keycloak session, so it doubles as a keep-alive.
+export async function refreshAccessToken(): Promise<string> {
+  cachedToken = null
+  return fetchAccessToken()
+}
+
 export interface TokenInfo {
   expiresAt: Date
   issuedAt: Date


### PR DESCRIPTION
## Summary
- The internal-frontend cached the Keycloak access token forever and only re-fetched on a 401. Between page load and the 15-minute access-token TTL, nothing pinged oauth2-proxy, so the 14-minute `cookie_refresh` never fired. By the time the retry path hit `/oauth2/auth`, the session was already stale and the user got bounced back to login — once every ~15 minutes.
- Adds `refreshAccessToken()` to the frontend API and schedules a `setTimeout` ~60 s before expiry, so oauth2-proxy refreshes the cookie + access token in time.
- Applied identically to `BitSwanInternalAppGolang` and `BitSwanInternalAppPythonFastapi`.

## Test plan
- [ ] Deploy one of the InternalApp examples to a stage with the standard 15 m access-token / 14 m cookie-refresh config.
- [ ] Open the internal frontend, leave it idle, and observe the **Token Info** card: the displayed TTL should reset (rise back to ~900 s) roughly once every 14 minutes instead of counting down to expiry.
- [ ] Wait >15 min, then click around (e.g., increment counter, upload image) — requests should succeed without redirecting to the Keycloak login page.
- [ ] Run `tsc --noEmit` / `vite build` in both `internal-frontend` directories to confirm no type errors.